### PR TITLE
Fix tests

### DIFF
--- a/AxolotlKitTests/AxolotlInMemoryStore.m
+++ b/AxolotlKitTests/AxolotlInMemoryStore.m
@@ -128,16 +128,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark IdentityKeyStore
 
-- (nullable ECKeyPair *)identityKeyPair
+- (nullable ECKeyPair *)identityKeyPair:(nullable id)protocolContext
 {
     return __identityKeyPair;
 }
 
-- (int)localRegistrationId{
+- (int)localRegistrationId:(nullable id)protocolContext {
     return __localRegistrationId;
 }
 
-- (BOOL)saveRemoteIdentity:(NSData *)identityKey recipientId:(NSString *)recipientId
+- (BOOL)saveRemoteIdentity:(NSData *)identityKey recipientId:(NSString *)recipientId protocolContext:(nullable id)protocolContext
 {
     NSData *existingKey = [self.trustedKeys objectForKey:recipientId];
 
@@ -152,6 +152,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)isTrustedIdentityKey:(NSData *)identityKey
                  recipientId:(NSString *)recipientId
                    direction:(TSMessageDirection)direction
+             protocolContext:(nullable id)protocolContext
 {
 
     NSData *data = [self.trustedKeys objectForKey:recipientId];
@@ -175,7 +176,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 # pragma mark Session Store
 
--(SessionRecord*)loadSession:(NSString*)contactIdentifier deviceId:(int)deviceId{
+-(SessionRecord*)loadSession:(NSString*)contactIdentifier deviceId:(int)deviceId protocolContext:(nullable id)protocolContext {
     SessionRecord *sessionRecord = [[self deviceSessionRecordsForContactIdentifier:contactIdentifier] objectForKey:[NSNumber numberWithInteger:deviceId]];
     
     if (!sessionRecord) {
@@ -194,7 +195,7 @@ NS_ASSUME_NONNULL_BEGIN
     return [self.sessionRecords objectForKey:contactIdentifier];
 }
 
-- (void)storeSession:(NSString*)contactIdentifier deviceId:(int)deviceId session:(SessionRecord *)session{
+- (void)storeSession:(NSString*)contactIdentifier deviceId:(int)deviceId session:(SessionRecord *)session protocolContext:(nullable id)protocolContext {
     NSAssert(session, @"Session can't be nil");
     NSMutableDictionary *deviceSessions = self.sessionRecords[contactIdentifier];
     if (!deviceSessions) {
@@ -205,7 +206,7 @@ NS_ASSUME_NONNULL_BEGIN
     self.sessionRecords[contactIdentifier] = deviceSessions;
 }
 
-- (BOOL)containsSession:(NSString*)contactIdentifier deviceId:(int)deviceId{
+- (BOOL)containsSession:(NSString*)contactIdentifier deviceId:(int)deviceId protocolContext:(nullable id)protocolContext {
     
     if ([[self.sessionRecords objectForKey:contactIdentifier] objectForKey:[NSNumber numberWithInt:deviceId]]){
         return YES;
@@ -213,14 +214,14 @@ NS_ASSUME_NONNULL_BEGIN
     return NO;
 }
 
-- (void)deleteSessionForContact:(NSString *)contactIdentifier deviceId:(int)deviceId
+- (void)deleteSessionForContact:(NSString *)contactIdentifier deviceId:(int)deviceId protocolContext:(nullable id)protocolContext
 {
     NSMutableDictionary<NSNumber *, SessionRecord *> *sessions =
         [self deviceSessionRecordsForContactIdentifier:contactIdentifier];
     [sessions removeObjectForKey:@(deviceId)];
 }
 
-- (void)deleteAllSessionsForContact:(NSString *)contactIdentifier
+- (void)deleteAllSessionsForContact:(NSString *)contactIdentifier protocolContext:(nullable id)protocolContext
 {
     [self.sessionRecords removeObjectForKey:contactIdentifier];
 }

--- a/AxolotlKitTests/RatchetingSessionTest.m
+++ b/AxolotlKitTests/RatchetingSessionTest.m
@@ -338,38 +338,38 @@
     XCTAssert([aliceSendingIVKeyData isEqualToData:aliceSessionRecord.sessionState.senderChainKey.messageKeys.iv]);
     XCTAssert([aliceSendingMacKeyData isEqualToData:aliceSessionRecord.sessionState.senderChainKey.messageKeys.macKey]);
     
-    [aliceStore storeSession:bobIdentifier deviceId:1 session:aliceSessionRecord];
+    [aliceStore storeSession:bobIdentifier deviceId:1 session:aliceSessionRecord protocolContext:nil];
     SessionCipher *aliceSessionCipher = [[SessionCipher alloc] initWithAxolotlStore:aliceStore recipientId:bobIdentifier deviceId:1];
     
-    WhisperMessage *message = [aliceSessionCipher encryptMessage:alicePlaintextData];
+    WhisperMessage *message = [aliceSessionCipher encryptMessage:alicePlaintextData protocolContext:nil];
     XCTAssert([aliceCipherTextData isEqualToData:message.cipherText]);
     
     // Logging's Bob's Session initialization and first message decryption
     
     XCTAssert([bobRootKeyData isEqualToData:bobSessionRecord.sessionState.rootKey.keyData]);
         
-    [bobStore storeSession:aliceIdentifier deviceId:1 session:bobSessionRecord];
+    [bobStore storeSession:aliceIdentifier deviceId:1 session:bobSessionRecord protocolContext:nil];
     
     SessionCipher *bobSessionCipher = [[SessionCipher alloc] initWithAxolotlStore:bobStore recipientId:aliceIdentifier deviceId:1];
     
-    NSData *plainData = [bobSessionCipher decrypt:message];
+    NSData *plainData = [bobSessionCipher decrypt:message protocolContext:nil];
     
     XCTAssert([plainData isEqualToData:alicePlaintextData]);
     
     for (int i = 0; i<100; i++) {
         NSData *message = [[NSString stringWithFormat:@"Message: %i", i] dataUsingEncoding:NSUTF8StringEncoding];
         
-        WhisperMessage *encrypted = [aliceSessionCipher encryptMessage:message];
+        WhisperMessage *encrypted = [aliceSessionCipher encryptMessage:message protocolContext:nil];
         
-        XCTAssert([message isEqualToData:[bobSessionCipher decrypt:encrypted]]);
+        XCTAssert([message isEqualToData:[bobSessionCipher decrypt:encrypted protocolContext:nil]]);
     }
     
     for (int i = 0; i<100; i++) {
         NSData *message = [[NSString stringWithFormat:@"Message: %i", i] dataUsingEncoding:NSUTF8StringEncoding];
         
-        WhisperMessage *encrypted = [bobSessionCipher encryptMessage:message];
+        WhisperMessage *encrypted = [bobSessionCipher encryptMessage:message protocolContext:nil];
         
-        XCTAssert([message isEqualToData:[aliceSessionCipher decrypt:encrypted]]);
+        XCTAssert([message isEqualToData:[aliceSessionCipher decrypt:encrypted protocolContext:nil]]);
     }
 
     NSMutableArray *plainTexts      = [NSMutableArray new];
@@ -378,11 +378,11 @@
     for (int i = 0 ; i < 100; i++) {
         NSData *message = [[NSString stringWithFormat:@"Message: %i", i] dataUsingEncoding:NSUTF8StringEncoding];
         [plainTexts addObject:message];
-        [cipherMessages addObject:[bobSessionCipher encryptMessage:message]];
+        [cipherMessages addObject:[bobSessionCipher encryptMessage:message protocolContext:nil]];
     }
     
     for (int i = 0; i < plainTexts.count; i++) {
-        XCTAssert([[aliceSessionCipher decrypt:[cipherMessages objectAtIndex:i]] isEqualToData:[plainTexts objectAtIndex:i]]);
+        XCTAssert([[aliceSessionCipher decrypt:[cipherMessages objectAtIndex:i] protocolContext:nil] isEqualToData:[plainTexts objectAtIndex:i]]);
     }
     
 }
@@ -686,21 +686,21 @@
     XCTAssert([aliceSendingIVKeyData isEqualToData:aliceSessionRecord.sessionState.senderChainKey.messageKeys.iv]);
     XCTAssert([aliceSendingMacKeyData isEqualToData:aliceSessionRecord.sessionState.senderChainKey.messageKeys.macKey]);
     
-    [aliceStore storeSession:bobIdentifier deviceId:1 session:aliceSessionRecord];
+    [aliceStore storeSession:bobIdentifier deviceId:1 session:aliceSessionRecord protocolContext:nil];
     SessionCipher *aliceSessionCipher = [[SessionCipher alloc] initWithAxolotlStore:aliceStore recipientId:bobIdentifier deviceId:1];
     
-    WhisperMessage *message = [aliceSessionCipher encryptMessage:alicePlaintextData];
+    WhisperMessage *message = [aliceSessionCipher encryptMessage:alicePlaintextData protocolContext:nil];
     XCTAssert([aliceCipherTextData isEqualToData:message.cipherText]);
     
     // Logging's Bob's Session initialization and first message decryption
     
     XCTAssert([bobRootKeyData isEqualToData:bobSessionRecord.sessionState.rootKey.keyData]);
     
-    [bobStore storeSession:aliceIdentifier deviceId:1 session:bobSessionRecord];
+    [bobStore storeSession:aliceIdentifier deviceId:1 session:bobSessionRecord protocolContext:nil];
     
     SessionCipher *bobSessionCipher = [[SessionCipher alloc] initWithAxolotlStore:bobStore recipientId:aliceIdentifier deviceId:1];
     
-    NSData *plainData = [bobSessionCipher decrypt:message];
+    NSData *plainData = [bobSessionCipher decrypt:message protocolContext:nil];
     
     XCTAssert([plainData isEqualToData:alicePlaintextData]);
     
@@ -711,11 +711,11 @@
     for (int i = 0 ; i < 30; i++) {
         NSData *message = [[NSString stringWithFormat:@"Message: %i", i] dataUsingEncoding:NSUTF8StringEncoding];
         [plainTexts addObject:message];
-        [cipherMessages addObject:[bobSessionCipher encryptMessage:message]];
+        [cipherMessages addObject:[bobSessionCipher encryptMessage:message protocolContext:nil]];
     }
     
     for (NSUInteger i = plainTexts.count-1; i > 0; i--) {
-        XCTAssert([[aliceSessionCipher decrypt:[cipherMessages objectAtIndex:i]] isEqualToData:[plainTexts objectAtIndex:i]]);
+        XCTAssert([[aliceSessionCipher decrypt:[cipherMessages objectAtIndex:i] protocolContext:nil] isEqualToData:[plainTexts objectAtIndex:i]]);
     }
     
 }

--- a/AxolotlKitTests/SessionBuilderTests.m
+++ b/AxolotlKitTests/SessionBuilderTests.m
@@ -48,26 +48,26 @@
     AxolotlInMemoryStore *bobStore      = [AxolotlInMemoryStore new];
     ECKeyPair *bobPreKeyPair            = [Curve25519 generateKeyPair];
     ECKeyPair *bobSignedPreKeyPair      = [Curve25519 generateKeyPair];
-    NSData    *bobSignedPreKeySignature = [Ed25519 sign:bobSignedPreKeyPair.publicKey withKeyPair:bobStore.identityKeyPair];
+    NSData    *bobSignedPreKeySignature = [Ed25519 sign:bobSignedPreKeyPair.publicKey withKeyPair:[bobStore identityKeyPair:nil]];
     
-    PreKeyBundle *bobPreKey = [[PreKeyBundle alloc]initWithRegistrationId:bobStore.localRegistrationId
+    PreKeyBundle *bobPreKey = [[PreKeyBundle alloc]initWithRegistrationId:[bobStore localRegistrationId:nil]
                                                                  deviceId:1
                                                                  preKeyId:31337
                                                              preKeyPublic:bobPreKeyPair.publicKey
                                                        signedPreKeyPublic:bobSignedPreKeyPair.publicKey
                                                            signedPreKeyId:22
                                                     signedPreKeySignature:bobSignedPreKeySignature
-                                                              identityKey:bobStore.identityKeyPair.publicKey];
+                                                              identityKey:[bobStore identityKeyPair:nil].publicKey];
     
-    [aliceSessionBuilder processPrekeyBundle:bobPreKey];
+    [aliceSessionBuilder processPrekeyBundle:bobPreKey protocolContext:nil];
     
-    XCTAssert([aliceStore containsSession:BOB_RECIPIENT_ID deviceId:1]);
-    XCTAssert([aliceStore loadSession:BOB_RECIPIENT_ID deviceId:1].sessionState.version == 3);
+    XCTAssert([aliceStore containsSession:BOB_RECIPIENT_ID deviceId:1 protocolContext:nil]);
+    XCTAssert([aliceStore loadSession:BOB_RECIPIENT_ID deviceId:1 protocolContext:nil].sessionState.version == 3);
         
     NSString *originalMessage = @"Freedom is the right to tell people what they do not want to hear.";
     SessionCipher *aliceSessionCipher = [[SessionCipher alloc] initWithAxolotlStore:aliceStore recipientId:BOB_RECIPIENT_ID deviceId:1];
     
-    WhisperMessage *outgoingMessage = [aliceSessionCipher encryptMessage:[originalMessage dataUsingEncoding:NSUTF8StringEncoding]];
+    WhisperMessage *outgoingMessage = [aliceSessionCipher encryptMessage:[originalMessage dataUsingEncoding:NSUTF8StringEncoding] protocolContext:nil];
     
     XCTAssert([outgoingMessage isKindOfClass:[PreKeyWhisperMessage class]], @"Message should be PreKey type");
     
@@ -76,11 +76,11 @@
     [bobStore storeSignedPreKey:22 signedPreKeyRecord:[[SignedPreKeyRecord alloc] initWithId:22 keyPair:bobSignedPreKeyPair signature:bobSignedPreKeySignature generatedAt:[NSDate date]]];
     
     SessionCipher *bobSessionCipher = [[SessionCipher alloc] initWithAxolotlStore:bobStore recipientId:ALICE_RECIPIENT_ID deviceId:1];
-    [bobSessionCipher decrypt:incomingMessage];
+    [bobSessionCipher decrypt:incomingMessage protocolContext:nil];
     
-    XCTAssert([bobStore containsSession:ALICE_RECIPIENT_ID deviceId:1]);
-    XCTAssert([bobStore loadSession:ALICE_RECIPIENT_ID deviceId:1].sessionState.version == 3);
-    XCTAssert([bobStore loadSession:ALICE_RECIPIENT_ID deviceId:1].sessionState.aliceBaseKey != nil);
+    XCTAssert([bobStore containsSession:ALICE_RECIPIENT_ID deviceId:1 protocolContext:nil]);
+    XCTAssert([bobStore loadSession:ALICE_RECIPIENT_ID deviceId:1 protocolContext:nil].sessionState.version == 3);
+    XCTAssert([bobStore loadSession:ALICE_RECIPIENT_ID deviceId:1 protocolContext:nil].sessionState.aliceBaseKey != nil);
 }
 
 /**
@@ -100,7 +100,7 @@
     ECKeyPair *bobSignedPreKeyPair1 = [Curve25519 generateKeyPair];
     NSData *bobSignedPreKeySignature1 = [Ed25519 sign:bobSignedPreKeyPair1.publicKey withKeyPair:bobIdentityKeyPair1];
 
-    PreKeyBundle *bobPreKey1 = [[PreKeyBundle alloc] initWithRegistrationId:bobStore.localRegistrationId
+    PreKeyBundle *bobPreKey1 = [[PreKeyBundle alloc] initWithRegistrationId:[bobStore localRegistrationId:nil]
                                                                    deviceId:1
                                                                    preKeyId:31337
                                                                preKeyPublic:bobPreKeyPair1.publicKey
@@ -109,16 +109,16 @@
                                                       signedPreKeySignature:bobSignedPreKeySignature1
                                                                 identityKey:bobIdentityKeyPair1.publicKey];
 
-    [aliceSessionBuilder processPrekeyBundle:bobPreKey1];
+    [aliceSessionBuilder processPrekeyBundle:bobPreKey1 protocolContext:nil];
 
-    XCTAssert([aliceStore containsSession:BOB_RECIPIENT_ID deviceId:1]);
-    XCTAssert([aliceStore loadSession:BOB_RECIPIENT_ID deviceId:1].sessionState.version == 3);
+    XCTAssert([aliceStore containsSession:BOB_RECIPIENT_ID deviceId:1 protocolContext:nil]);
+    XCTAssert([aliceStore loadSession:BOB_RECIPIENT_ID deviceId:1 protocolContext:nil].sessionState.version == 3);
 
     NSString *messageText = @"Freedom is the right to tell people what they do not want to hear.";
     SessionCipher *aliceSessionCipher = [[SessionCipher alloc] initWithAxolotlStore:aliceStore recipientId:BOB_RECIPIENT_ID deviceId:1];
 
     WhisperMessage *outgoingMessage1 =
-        [aliceSessionCipher encryptMessage:[messageText dataUsingEncoding:NSUTF8StringEncoding]];
+        [aliceSessionCipher encryptMessage:[messageText dataUsingEncoding:NSUTF8StringEncoding] protocolContext:nil];
 
     XCTAssert([outgoingMessage1 isKindOfClass:[PreKeyWhisperMessage class]], @"Message should be PreKey type");
 
@@ -127,7 +127,7 @@
     ECKeyPair *bobSignedPreKeyPair2 = [Curve25519 generateKeyPair];
     NSData *bobSignedPreKeySignature2 = [Ed25519 sign:bobSignedPreKeyPair2.publicKey withKeyPair:bobIdentityKeyPair2];
 
-    PreKeyBundle *bobPreKey2 = [[PreKeyBundle alloc] initWithRegistrationId:bobStore.localRegistrationId
+    PreKeyBundle *bobPreKey2 = [[PreKeyBundle alloc] initWithRegistrationId:[bobStore localRegistrationId:nil]
                                                                    deviceId:1
                                                                    preKeyId:31337
                                                                preKeyPublic:bobPreKeyPair2.publicKey
@@ -137,7 +137,7 @@
                                                                 identityKey:bobIdentityKeyPair2.publicKey];
 
     XCTAssertThrowsSpecificNamed(
-        [aliceSessionBuilder processPrekeyBundle:bobPreKey2], NSException, UntrustedIdentityKeyException);
+        [aliceSessionBuilder processPrekeyBundle:bobPreKey2 protocolContext:nil], NSException, UntrustedIdentityKeyException);
 }
 
 

--- a/AxolotlKitTests/SessionCipherTest.m
+++ b/AxolotlKitTests/SessionCipherTest.m
@@ -56,30 +56,6 @@
     [self runInteractionWithAliceRecord:aliceSessionRecord bobRecord:bobSessionRecord];
 }
 
-- (void)testBasicSessionCipherDispatchQueue {
-    SessionRecord *aliceSessionRecord = [SessionRecord new];
-    SessionRecord *bobSessionRecord   = [SessionRecord new];
-
-    XCTestExpectation *expectation = [self expectationWithDescription:@"session cipher completed"];
-
-    dispatch_queue_t sessionCipherDispatchQueue = dispatch_queue_create("session cipher queue", DISPATCH_QUEUE_SERIAL);
-
-    [SessionCipher setSessionCipherDispatchQueue:sessionCipherDispatchQueue];
-    dispatch_async(sessionCipherDispatchQueue, ^{
-        [self sessionInitializationWithAliceSessionRecord:aliceSessionRecord bobSessionRecord:bobSessionRecord];
-        [self runInteractionWithAliceRecord:aliceSessionRecord bobRecord:bobSessionRecord];
-
-        [expectation fulfill];
-    });
-
-    [self waitForExpectationsWithTimeout:5.0 handler:^(NSError * _Nullable error) {
-        if (error) {
-            XCTFail(@"Expectation failed with error: %@", error);
-        }
-    }];
-    [SessionCipher setSessionCipherDispatchQueue:nil];
-}
-
 - (void)testPromotingOldSessionState
 {
     SessionRecord *aliceSessionRecord = [SessionRecord new];

--- a/AxolotlKitTests/SessionCipherTest.m
+++ b/AxolotlKitTests/SessionCipherTest.m
@@ -65,7 +65,7 @@
     SessionState *initialSessionState = bobSessionRecord.sessionState;
     [self sessionInitializationWithAliceSessionRecord:aliceSessionRecord bobSessionRecord:bobSessionRecord];
 
-    SessionRecord *activeSession = [self.bobStore loadSession:self.aliceIdentifier deviceId:1];
+    SessionRecord *activeSession = [self.bobStore loadSession:self.aliceIdentifier deviceId:1 protocolContext:nil];
     XCTAssertNotNil(activeSession);
     XCTAssertEqualObjects(initialSessionState, activeSession.sessionState);
 
@@ -73,9 +73,9 @@
     SessionState *newSessionState = [SessionState new];
     [bobSessionRecord promoteState:newSessionState];
     XCTAssertEqual(1, bobSessionRecord.previousSessionStates.count);
-    [self.bobStore storeSession:self.aliceIdentifier deviceId:1 session:bobSessionRecord];
+    [self.bobStore storeSession:self.aliceIdentifier deviceId:1 session:bobSessionRecord protocolContext:nil];
 
-    activeSession = [self.bobStore loadSession:self.aliceIdentifier deviceId:1];
+    activeSession = [self.bobStore loadSession:self.aliceIdentifier deviceId:1 protocolContext:nil];
     XCTAssertNotNil(activeSession);
     XCTAssertNotEqualObjects(initialSessionState, activeSession.sessionState);
     XCTAssertEqualObjects(newSessionState, activeSession.sessionState);
@@ -110,11 +110,11 @@
     
     [RatchetingSession initializeSession:aliceSessionState sessionVersion:3 AliceParameters:aliceParams];
 
-    [self.aliceStore saveRemoteIdentity:bobIdentityKeyPair.publicKey recipientId:self.bobIdentifier];
-    [self.aliceStore storeSession:self.bobIdentifier deviceId:1 session:aliceSessionRecord];
+    [self.aliceStore saveRemoteIdentity:bobIdentityKeyPair.publicKey recipientId:self.bobIdentifier protocolContext:nil];
+    [self.aliceStore storeSession:self.bobIdentifier deviceId:1 session:aliceSessionRecord protocolContext:nil];
 
-    [self.bobStore saveRemoteIdentity:aliceIdentityKeyPair.publicKey recipientId:self.aliceIdentifier];
-    [self.bobStore storeSession:self.aliceIdentifier deviceId:1 session:bobSessionRecord];
+    [self.bobStore saveRemoteIdentity:aliceIdentityKeyPair.publicKey recipientId:self.aliceIdentifier protocolContext:nil];
+    [self.bobStore storeSession:self.aliceIdentifier deviceId:1 session:bobSessionRecord protocolContext:nil];
 
     XCTAssert([aliceSessionState.remoteIdentityKey isEqualToData:bobSessionState.localIdentityKey]);
 }
@@ -126,9 +126,9 @@
         [[SessionCipher alloc] initWithAxolotlStore:self.bobStore recipientId:self.aliceIdentifier deviceId:1];
 
     NSData *alicePlainText     = [@"This is a plaintext message!" dataUsingEncoding:NSUTF8StringEncoding];
-    WhisperMessage *cipherText = [aliceSessionCipher encryptMessage:alicePlainText];
+    WhisperMessage *cipherText = [aliceSessionCipher encryptMessage:alicePlainText protocolContext:nil];
     
-    NSData *bobPlaintext = [bobSessionCipher decrypt:cipherText];
+    NSData *bobPlaintext = [bobSessionCipher decrypt:cipherText protocolContext:nil];
     
     XCTAssert([bobPlaintext isEqualToData:alicePlainText]);
 }


### PR DESCRIPTION
With this branch, the tests can be run and succeed again.

This is achieved by removing the test for a method that does no longer exist, and by adding the `protocolContext` parameter where it was missing.

@charlesmchen, could you please have a look? From the Git log, it looks like you have experience with this parameter. Thanks in advance!